### PR TITLE
Swap google/cloud out for google/cloud-pubsub.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=5.6.0",
     "superbalist/php-pubsub": "^2.0",
-    "google/cloud": "^0.33.0|^0.34.0|^0.35.0"
+    "google/cloud-pubsub": ">=1.0 <1.4"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
When installing the following packages together, and having `"optimize-autoloader": true` in your `composer.json`:

- `superbalist/laravel-pubsub`
- `superbalist/laravel-google-cloud-storage`

You get a wall of warnings like this on `composer install`:

```
Warning: Ambiguous class resolution, "Google\Cloud\Core\RequestWrapper" was found in both "/Users/andrew/Developer/salesmessage/service-auth/vendor/google/cloud-core/src/RequestWrapper.php" and "/Users/andrew/Developer/salesmessage/service-auth/vendor/google/cloud/src/Core/RequestWrapper.php", the first will be used.
Warning: Ambiguous class resolution, "Google\Cloud\Core\ClientTrait" was found in both "/Users/andrew/Developer/salesmessage/service-auth/vendor/google/cloud-core/src/ClientTrait.php" and "/Users/andrew/Developer/salesmessage/service-auth/vendor/google/cloud/src/Core/ClientTrait.php", the first will be used.
```

This is because this package is including the entire `google/cloud` dependency, when it only needs `google/cloud-pubsub`.

This change will put your version constraints in line with your other packages. I have forked both repos and conducted a test to ensure this warning is removed. All checks out.