### PR TITLE
pull return immediately, with sleep

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.1 - 2019-03-19
+
+* Add ability to use returnImmediately flag when pulling messages 
+
 ## 5.1.0 - 2019-02-28
 
 * Bump up google/cloud requirement to ^0.95.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.1.1 - 2019-03-19
+## 5.2.0 - 2019-03-19
 
 * Add ability to use returnImmediately flag when pulling messages 
 

--- a/src/GoogleCloudPubSubAdapter.php
+++ b/src/GoogleCloudPubSubAdapter.php
@@ -75,7 +75,7 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
         $this->backgroundBatching = $backgroundBatching;
         $this->maxMessages = $maxMessages;
         $this->returnImmediately = $returnImmediately;
-        $this->returnImmediatelyPause = $returnImmediatelyPause;
+        $this->returnImmediatelyPause = (int) $returnImmediatelyPause;
     }
 
     /**

--- a/src/GoogleCloudPubSubAdapter.php
+++ b/src/GoogleCloudPubSubAdapter.php
@@ -41,6 +41,16 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
     protected $maxMessages;
 
     /**
+     * @var bool
+     */
+    protected $returnImmediately;
+
+    /**
+     * @var int
+     */
+    protected $returnImmediatelyPause;
+
+    /**
      * @param PubSubClient $client
      * @param string $clientIdentifier
      * @param bool $autoCreateTopics
@@ -54,7 +64,9 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
         $autoCreateTopics = true,
         $autoCreateSubscriptions = true,
         $backgroundBatching = false,
-        $maxMessages = 1000
+        $maxMessages = 1000,
+        $returnImmediately = false,
+        $returnImmediatelyPause = 500000
     ) {
         $this->client = $client;
         $this->clientIdentifier = $clientIdentifier;
@@ -62,6 +74,8 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
         $this->autoCreateSubscriptions = $autoCreateSubscriptions;
         $this->backgroundBatching = $backgroundBatching;
         $this->maxMessages = $maxMessages;
+        $this->returnImmediately = $returnImmediately;
+        $this->returnImmediatelyPause = $returnImmediatelyPause;
     }
 
     /**
@@ -141,6 +155,40 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
     }
 
     /**
+     * Set if a pull should return immediately if there are no messages
+     * @param bool $returnImmediately
+     */
+    public function setReturnImmediately($returnImmediately) {
+        $this->returnImmediately = $returnImmediately;
+    }
+
+    /**
+     * Return the return immediately configuration
+     * @return bool
+     */
+    public function getReturnImmediately() {
+        return $this->returnImmediately;
+    }
+
+    /**
+     * Set the amount of time to pause between attempts to pull messages if return immediately is enabled.
+     * Value is in microseconds
+     *
+     * @param $returnImmediatelyPause
+     */
+    public function setReturnImmediatelyPause($returnImmediatelyPause) {
+        $this->returnImmediatelyPause = $returnImmediatelyPause;
+    }
+
+    /**
+     * Return the return immediately pause configuration
+     * @return int
+     */
+    public function getReturnImmediatelyPause() {
+        return $this->returnImmediatelyPause;
+    }
+
+    /**
      * Set whether or not background batching is enabled.
      *
      * This is available from Google Cloud 0.33+ - https://github.com/GoogleCloudPlatform/google-cloud-php/releases/tag/v0.33.0
@@ -198,10 +246,10 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
                     'timeoutMillis' => null,
                 ],
                 'maxMessages' => $this->maxMessages,
-                'returnImmediately' => true,
+                'returnImmediately' => $this->returnImmediately,
             ]);
-            if ( ! $messages || count($messages) < 1) {
-                usleep(200000);
+            if ($this->returnImmediately && empty($messages)) {
+                usleep($this->returnImmediatelyPause);
                 continue;
             }
             foreach ($messages as $message) {

--- a/src/GoogleCloudPubSubAdapter.php
+++ b/src/GoogleCloudPubSubAdapter.php
@@ -174,10 +174,10 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
      * Set the amount of time to pause between attempts to pull messages if return immediately is enabled.
      * Value is in microseconds
      *
-     * @param $returnImmediatelyPause
+     * @param int $returnImmediatelyPause
      */
     public function setReturnImmediatelyPause($returnImmediatelyPause) {
-        $this->returnImmediatelyPause = $returnImmediatelyPause;
+        $this->returnImmediatelyPause = (int) $returnImmediatelyPause;
     }
 
     /**
@@ -239,6 +239,7 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
         $subscription = $this->getSubscriptionForChannel($channel);
 
         $isSubscriptionLoopActive = true;
+        $isPauseEnabled = $this->returnImmediately && ($this->returnImmediatelyPause > 0);
 
         while ($isSubscriptionLoopActive) {
             $messages = $subscription->pull([
@@ -248,7 +249,7 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
                 'maxMessages' => $this->maxMessages,
                 'returnImmediately' => $this->returnImmediately,
             ]);
-            if ($this->returnImmediately && empty($messages)) {
+            if ($isPauseEnabled && empty($messages)) {
                 usleep($this->returnImmediatelyPause);
                 continue;
             }

--- a/src/GoogleCloudPubSubAdapter.php
+++ b/src/GoogleCloudPubSubAdapter.php
@@ -198,8 +198,12 @@ class GoogleCloudPubSubAdapter implements PubSubAdapterInterface
                     'timeoutMillis' => null,
                 ],
                 'maxMessages' => $this->maxMessages,
+                'returnImmediately' => true,
             ]);
-
+            if ( ! $messages || count($messages) < 1) {
+                usleep(200000);
+                continue;
+            }
             foreach ($messages as $message) {
                 /** @var Message $message */
                 $payload = Utils::unserializeMessagePayload($message->data());


### PR DESCRIPTION
Add the ability to configure the client to use the `returnImmediately` parameter.